### PR TITLE
fix(reader): structural transform-based pagination to stop OS auto-scroll (#20)

### DIFF
--- a/src/features/reader/foliate-js-runtime/paginator.js
+++ b/src/features/reader/foliate-js-runtime/paginator.js
@@ -454,6 +454,13 @@ export class Paginator extends HTMLElement {
     // the flag alive; expires 1.5s after the last selection change.
     // Used to suppress touch swipe page-turns while the user is selecting.
     #selectionActiveUntil = 0
+    // Abstract scroll position for paginated mode. With #container set to
+    // `overflow: clip` it can no longer be scrolled (even programmatically),
+    // so pages are panned via `transform` on the view element. This field
+    // holds the offset that *would* have been #container[scrollProp]; all
+    // navigation math (start/end/page/snap/scrollBy) reads it instead of
+    // the inert scrollLeft/scrollTop. (#20 structural fix.)
+    #pageOffset = 0
     constructor() {
         super()
         this.#root.innerHTML = `<style>
@@ -511,11 +518,17 @@ export class Paginator extends HTMLElement {
         #container {
             grid-column: 2 / 5;
             grid-row: 2;
-            overflow: hidden;
+            /* clip (not hidden) makes #container a non-scroll container:
+             * scrollLeft/scrollTop become inert, so Android WebView's
+             * OS-level auto-scroll during native text selection can no
+             * longer move the page (#20). Pages are instead positioned
+             * via transform on the view element (#setViewPosition). */
+            overflow: clip;
         }
         :host([flow="scrolled"]) #container {
             grid-column: 1 / -1;
             grid-row: 1 / -1;
+            /* scrolled mode keeps real scrolling */
             overflow: auto;
         }
         #header {
@@ -802,7 +815,12 @@ export class Paginator extends HTMLElement {
         return this.#view.element.getBoundingClientRect()[this.sideProp]
     }
     get start() {
-        return Math.abs(this.#container[this.scrollProp])
+        // Scrolled mode keeps a real scroll container; paginated mode
+        // reads the abstract offset (#container is overflow:clip and
+        // cannot be scrolled, even programmatically).
+        return this.scrolled
+            ? Math.abs(this.#container[this.scrollProp])
+            : Math.abs(this.#pageOffset)
     }
     get end() {
         return this.start + this.size
@@ -813,16 +831,37 @@ export class Paginator extends HTMLElement {
     get pages() {
         return Math.round(this.viewSize / this.size)
     }
+    // Position the page in paginated mode without scrolling #container
+    // (which is overflow:clip and inert). Pans the wide view element via
+    // transform; the visual result is identical to the old scrollLeft set.
+    #setViewPosition(offset) {
+        this.#pageOffset = offset
+        const el = this.#view?.element
+        if (el) {
+            const axis = this.#vertical ? 'Y' : 'X'
+            el.style.transform = `translate${axis}(${-offset}px)`
+        }
+        // Preserve the 'scroll' event the container used to emit on
+        // programmatic scroll (external listeners may rely on it).
+        this.dispatchEvent(new Event('scroll'))
+    }
     scrollBy(dx, dy) {
         const delta = this.#vertical ? dy : dx
-        const element = this.#container
-        const { scrollProp } = this
         const [offset, a, b] = this.#scrollBounds
         const rtl = this.#rtl
         const min = rtl ? offset - b : offset - a
         const max = rtl ? offset + a : offset + b
-        element[scrollProp] = Math.max(min, Math.min(max,
-            element[scrollProp] + delta))
+        if (this.scrolled) {
+            const element = this.#container
+            const { scrollProp } = this
+            element[scrollProp] = Math.max(min, Math.min(max,
+                element[scrollProp] + delta))
+        } else {
+            // Paginated: #container is non-scrollable (overflow:clip),
+            // so pan the view via transform instead.
+            const next = Math.max(min, Math.min(max, this.#pageOffset + delta))
+            this.#setViewPosition(next)
+        }
     }
     snap(vx, vy) {
         const velocity = this.#vertical ? vy : vx
@@ -933,24 +972,33 @@ export class Paginator extends HTMLElement {
         return this.#scrollToPage(Math.floor(offset / this.size) + (this.#rtl ? -1 : 1), reason)
     }
     async #scrollTo(offset, reason, smooth) {
-        const element = this.#container
-        const { scrollProp, size } = this
-        if (element[scrollProp] === offset) {
+        const { size } = this
+        const scrolled = this.scrolled
+        // Paginated mode pans the view via transform (#container is
+        // overflow:clip and cannot be scrolled). Scrolled mode keeps
+        // real container scrolling.
+        const cur = () => scrolled
+            ? this.#container[this.scrollProp]
+            : this.#pageOffset
+        const apply = x => scrolled
+            ? this.#container[this.scrollProp] = x
+            : this.#setViewPosition(x)
+        if (cur() === offset) {
             this.#scrollBounds = [offset, this.atStart ? 0 : size, this.atEnd ? 0 : size]
             this.#afterScroll(reason)
             return
         }
         // FIXME: vertical-rl only, not -lr
-        if (this.scrolled && this.#vertical) offset = -offset
+        if (scrolled && this.#vertical) offset = -offset
         if ((reason === 'snap' || smooth) && this.hasAttribute('animated')) return animate(
-            element[scrollProp], offset, 300, easeOutQuad,
-            x => element[scrollProp] = x,
+            cur(), offset, 300, easeOutQuad,
+            apply,
         ).then(() => {
             this.#scrollBounds = [offset, this.atStart ? 0 : size, this.atEnd ? 0 : size]
             this.#afterScroll(reason)
         })
         else {
-            element[scrollProp] = offset
+            apply(offset)
             this.#scrollBounds = [offset, this.atStart ? 0 : size, this.atEnd ? 0 : size]
             this.#afterScroll(reason)
         }


### PR DESCRIPTION
## Summary

Fixes #20 — *Android: highlighting on second column of a page jumps to random column/page.*

Replaces the abandoned scroll-pin approach (old PR #28, closed) with the **structural fix** the June 30 investigation named as the only real solution: **remove the scrollable container so Android's OS-level auto-scroll has nothing to hijack.**

### Why the previous fixes were not enough
Commits `e88be7c`, `be98976`, `488ecb2`, `7375aa6` blocked every **JS-level** cause (checkPointerSelection auto-navigation, focusin→scrollToAnchor, touchmove swipe). But one mechanism remained and cannot be beaten from JS: **Android WebView's OS-level auto-scroll of `#container.scrollLeft` during native text selection** — the browser moves the CSS multi-column container directly to keep OS selection handles visible, bypassing all JavaScript handlers. The scroll-pin/rAF-restore attempt (PR #28) lost that fight because the OS writes `scrollLeft` directly, faster than JS can correct it.

### The structural fix (paginated mode only; scrolled mode untouched)
- **`#container`: `overflow: hidden` → `overflow: clip`.** `clip` makes the element a **non-scroll container** — `scrollLeft`/`scrollTop` are fully inert, so the OS auto-scroll becomes a no-op. (`overflow: hidden` was still programmatically scrollable, which is exactly what the OS exploited.)
- **Pages now pan via `transform: translateX/Y()`** on the view element instead of setting `#container.scrollLeft`. New `#pageOffset` field + `#setViewPosition()` method.
- **`start` getter, `scrollBy`, `#scrollTo`** branch on `this.scrolled`: scrolled keeps real container scrolling; paginated reads `#pageOffset` and applies transform.
- **`#setViewPosition` dispatches the `scroll` event** the container used to emit, preserving external-listener behavior.

### Why this is low-risk for CFI / annotations / resume
All navigation math funnels through `#scrollTo` → `#setViewPosition`. The `start`/`end`/`page`/`pages` getters now read `#pageOffset` in paginated mode, so `#getVisibleRange`, `#scrollToRect`, `#scrollToAnchor`, `snap`, relocate events, and fraction computation are unchanged. The iframe content layout (CSS columns) is untouched — only the outer panning mechanism changed. The visual result of a given page offset is identical to the old `scrollLeft` set.

### Browser support
`overflow: clip`: Chrome 90+, Firefox 81+, Safari 16+, Android System WebView (Chromium). All current targets.

### Validation
- `node --check paginator.js` — clean
- `pnpm typecheck` — pass
- `pnpm build` — pass (paginator bundle builds)
- `pnpm test` — 85/86 pass; the 1 failure is a pre-existing flaky **timing** assertion in `dictionary.test.ts` (binary-search < 15µs), unrelated to this change — it passes when run in isolation (5/5). This PR only touches `paginator.js`.

### Note
On-device verification on a real Android device with a multi-column EPUB is the final confirmation. The earlier JS-level guards are intentionally kept and now coexist with this structural fix.